### PR TITLE
feat(auth): save and reuse connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A terminal-based explorer for Azure Service Bus.
 - Interactive browser authentication
 - Service principal (client ID / client secret)
 - Connection string
+- Optional save prompt after connection-string login
+- Saved connection strings list with quick connect and delete
 - Emulator (one-click connect to local Service Bus emulator)
 
 ### Namespace Discovery
@@ -100,11 +102,21 @@ service-bus-tui
 
 Select an authentication method, choose a namespace, and browse your Service Bus resources.
 
+If you authenticate with a connection string, the app prompts you to optionally save it for later reuse.
+
 ## Emulator Support
 
 Supports the [Azure Service Bus emulator](https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator) running in Docker. Select **Emulator (localhost)** from the auth menu for default port.
 
 **Limitation**: Total message count is unavailable (SDK bug) — page indicator shows "?" but pagination works normally.
+
+## Saved Connection Strings
+
+Saved connection strings are stored locally as plain JSON at:
+
+`~/.config/service-bus-tui/connections.json`
+
+The app writes this file with restrictive permissions (directory `0700`, file `0600`).
 
 ## Requirements
 

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 const (
@@ -26,30 +27,49 @@ const (
 	InteractiveBrowser
 	ServicePrincipal
 	ConnectionString
+	SavedConnections
 	Emulator
 )
 
+type savePromptFocus int
+
+const (
+	savePromptFocusName savePromptFocus = iota
+	savePromptFocusSave
+	savePromptFocusSkip
+)
+
 type AuthModel struct {
-	selectedAuth           CredentialType
-	authOptions            []string
-	credentialTypes        []CredentialType
-	inNamespaceMode        bool
-	inConnectionStringMode bool
-	connectionStringInput  textinput.Model
-	inServicePrincipalMode bool
-	servicePrincipalInputs [4]textinput.Model
-	focusedSPInput         int
-	spTenantID             string
-	spClientID             string
-	spClientSecret         string
-	errMsg                 string
-	isAuthenticating       bool
-	namespaces             []azure.NamespaceInfo
-	selectedNamespaceIdx   int
-	authenticatedUser      string
-	spinner                spinner.Model
-	height                 int
-	scrollOffset           int
+	selectedAuth            CredentialType
+	authOptions             []string
+	credentialTypes         []CredentialType
+	inNamespaceMode         bool
+	inConnectionStringMode  bool
+	inSavedConnectionsMode  bool
+	inSaveConnectionPrompt  bool
+	connectionStringInput   textinput.Model
+	saveNameInput           textinput.Model
+	savePromptFocus         savePromptFocus
+	inServicePrincipalMode  bool
+	servicePrincipalInputs  [4]textinput.Model
+	focusedSPInput          int
+	store                   *ConnectionStore
+	savedConnections        []SavedConnection
+	selectedSavedIdx        int
+	pendingConnection       *NamespaceConnectedMsg
+	pendingConnectionString string
+	spTenantID              string
+	spClientID              string
+	spClientSecret          string
+	errMsg                  string
+	isAuthenticating        bool
+	namespaces              []azure.NamespaceInfo
+	selectedNamespaceIdx    int
+	authenticatedUser       string
+	spinner                 spinner.Model
+	width                   int
+	height                  int
+	scrollOffset            int
 }
 
 func NewAuthModel() *AuthModel {
@@ -61,6 +81,10 @@ func NewAuthModel() *AuthModel {
 	ti.EchoMode = textinput.EchoPassword
 	ti.EchoCharacter = '*'
 	ti.Width = 80
+
+	saveNameInput := textinput.New()
+	saveNameInput.Placeholder = "my-namespace"
+	saveNameInput.Width = 40
 
 	// Service Principal text inputs: Tenant ID, Client ID, Client Secret, Namespace (optional)
 	var spInputs [4]textinput.Model
@@ -76,36 +100,25 @@ func NewAuthModel() *AuthModel {
 	spInputs[3].Placeholder = "my-namespace"
 
 	m := &AuthModel{
-		authOptions: []string{
-			"Interactive Browser",
-			"Service Principal",
-			"Connection String",
-			"Emulator (localhost)",
-		},
-		credentialTypes: []CredentialType{
-			InteractiveBrowser,
-			ServicePrincipal,
-			ConnectionString,
-			Emulator,
-		},
+		store:                  NewConnectionStore(),
 		selectedAuth:           0,
 		connectionStringInput:  ti,
+		saveNameInput:          saveNameInput,
 		servicePrincipalInputs: spInputs,
 		spinner:                s,
+		width:                  100,
 		height:                 50,
 		scrollOffset:           0,
 	}
 
+	if saved, err := m.store.List(); err == nil {
+		m.savedConnections = saved
+	}
+	m.refreshAuthOptions()
+
 	if user, ok := azure.GetAzureCliAuthenticatedUser(); ok {
 		m.authenticatedUser = user
-		m.authOptions = append(
-			[]string{fmt.Sprintf("Azure CLI, authenticated as %s", user)},
-			m.authOptions...,
-		)
-		m.credentialTypes = append(
-			[]CredentialType{AzureCLI},
-			m.credentialTypes...,
-		)
+		m.refreshAuthOptions()
 		m.selectedAuth = 0
 	}
 
@@ -123,6 +136,58 @@ func (m *AuthModel) selectedCredentialType() CredentialType {
 	return m.credentialTypes[0]
 }
 
+func (m *AuthModel) refreshAuthOptions() {
+	authOptions := []string{
+		"Interactive Browser",
+		"Service Principal",
+		"Connection String",
+	}
+	credentialTypes := []CredentialType{
+		InteractiveBrowser,
+		ServicePrincipal,
+		ConnectionString,
+	}
+
+	if len(m.savedConnections) > 0 {
+		authOptions = append(authOptions, "Saved Connection Strings")
+		credentialTypes = append(credentialTypes, SavedConnections)
+	}
+
+	authOptions = append(authOptions, "Emulator (localhost)")
+	credentialTypes = append(credentialTypes, Emulator)
+
+	if m.authenticatedUser != "" {
+		authOptions = append(
+			[]string{fmt.Sprintf("Azure CLI, authenticated as %s", m.authenticatedUser)},
+			authOptions...,
+		)
+		credentialTypes = append([]CredentialType{AzureCLI}, credentialTypes...)
+	}
+
+	m.authOptions = authOptions
+	m.credentialTypes = credentialTypes
+	if len(m.authOptions) == 0 {
+		m.selectedAuth = 0
+		return
+	}
+	if int(m.selectedAuth) >= len(m.authOptions) {
+		m.selectedAuth = CredentialType(len(m.authOptions) - 1)
+	}
+}
+
+func (m *AuthModel) refreshSavedConnections() error {
+	saved, err := m.store.List()
+	if err != nil {
+		return err
+	}
+	m.savedConnections = saved
+	m.refreshAuthOptions()
+	if m.selectedSavedIdx >= len(m.savedConnections) {
+		m.selectedSavedIdx = max(0, len(m.savedConnections)-1)
+	}
+	return nil
+}
+
 func (m *AuthModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var spinnerCmd tea.Cmd
 	m.spinner, spinnerCmd = m.spinner.Update(msg)
@@ -133,6 +198,14 @@ func (m *AuthModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c":
 			return m, tea.Quit
 		case "esc":
+			if m.inSaveConnectionPrompt {
+				return m.skipPendingConnection()
+			}
+			if m.inSavedConnectionsMode {
+				m.inSavedConnectionsMode = false
+				m.errMsg = ""
+				return m, spinnerCmd
+			}
 			if m.inConnectionStringMode {
 				m.inConnectionStringMode = false
 				m.connectionStringInput.SetValue("")
@@ -157,7 +230,11 @@ func (m *AuthModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, spinnerCmd
 		}
 
-		if m.inConnectionStringMode {
+		if m.inSaveConnectionPrompt {
+			return m.updateSaveConnectionPrompt(msg)
+		} else if m.inSavedConnectionsMode {
+			return m.updateSavedConnections(msg)
+		} else if m.inConnectionStringMode {
 			return m.updateConnectionStringInput(msg)
 		} else if m.inServicePrincipalMode {
 			return m.updateServicePrincipalInput(msg)
@@ -168,6 +245,7 @@ func (m *AuthModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.WindowSizeMsg:
+		m.width = max(msg.Width, 20)
 		m.height = max(msg.Height-5, 5)
 
 	case NamespacesLoadedMsg:
@@ -182,6 +260,18 @@ func (m *AuthModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.errMsg = string(msg)
 		m.isAuthenticating = false
 		return m, spinnerCmd
+
+	case ConnectionStringConnectedMsg:
+		m.isAuthenticating = false
+		m.inSaveConnectionPrompt = true
+		m.savePromptFocus = savePromptFocusName
+		m.pendingConnectionString = msg.ConnectionString
+		m.pendingConnection = &NamespaceConnectedMsg{Namespace: msg.Namespace, Client: msg.Client}
+		defaultName := strings.TrimSpace(msg.Namespace)
+		m.saveNameInput.SetValue(defaultName)
+		m.saveNameInput.Focus()
+		m.errMsg = ""
+		return m, textinput.Blink
 	}
 
 	return m, spinnerCmd
@@ -220,6 +310,19 @@ func (m *AuthModel) updateAuthSelection(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.isAuthenticating = true
 			return m, tea.Batch(m.spinner.Tick, m.connectWithConnectionStringCmd(emulatorConnectionString))
 		}
+		if m.selectedCredentialType() == SavedConnections {
+			if err := m.refreshSavedConnections(); err != nil {
+				m.errMsg = err.Error()
+				return m, nil
+			}
+			if len(m.savedConnections) == 0 {
+				m.errMsg = "no saved connection strings"
+				return m, nil
+			}
+			m.inSavedConnectionsMode = true
+			m.selectedSavedIdx = 0
+			return m, nil
+		}
 		if m.selectedCredentialType() == ConnectionString {
 			m.inConnectionStringMode = true
 			m.connectionStringInput.Focus()
@@ -248,12 +351,141 @@ func (m *AuthModel) updateConnectionStringInput(msg tea.KeyMsg) (tea.Model, tea.
 		m.errMsg = ""
 		m.isAuthenticating = true
 		m.inConnectionStringMode = false
-		return m, tea.Batch(m.spinner.Tick, m.connectWithConnectionStringCmd(connStr))
+		return m, tea.Batch(m.spinner.Tick, m.connectWithConnectionStringAndPromptCmd(connStr))
 	default:
 		var cmd tea.Cmd
 		m.connectionStringInput, cmd = m.connectionStringInput.Update(msg)
 		return m, cmd
 	}
+}
+
+func (m *AuthModel) updateSavedConnections(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if len(m.savedConnections) == 0 {
+		m.inSavedConnectionsMode = false
+		m.refreshAuthOptions()
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.selectedSavedIdx > 0 {
+			m.selectedSavedIdx--
+		}
+	case "down", "j":
+		if m.selectedSavedIdx < len(m.savedConnections)-1 {
+			m.selectedSavedIdx++
+		}
+	case "enter":
+		entry := m.savedConnections[m.selectedSavedIdx]
+		m.inSavedConnectionsMode = false
+		m.isAuthenticating = true
+		m.errMsg = ""
+		return m, tea.Batch(m.spinner.Tick, m.connectWithConnectionStringCmd(entry.ConnectionString))
+	case "x", "delete":
+		entry := m.savedConnections[m.selectedSavedIdx]
+		if err := m.store.Delete(entry.ID); err != nil {
+			m.errMsg = fmt.Sprintf("failed to delete saved connection: %v", err)
+			return m, nil
+		}
+		if err := m.refreshSavedConnections(); err != nil {
+			m.errMsg = err.Error()
+			return m, nil
+		}
+		if len(m.savedConnections) == 0 {
+			m.inSavedConnectionsMode = false
+			m.errMsg = ""
+		}
+	}
+
+	return m, nil
+}
+
+func (m *AuthModel) updateSaveConnectionPrompt(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "tab":
+		m.moveSavePromptFocus(1)
+		return m, textinput.Blink
+	case "shift+tab":
+		m.moveSavePromptFocus(-1)
+		return m, textinput.Blink
+	case "left", "h":
+		if m.savePromptFocus == savePromptFocusSkip {
+			m.setSavePromptFocus(savePromptFocusSave)
+		}
+		return m, textinput.Blink
+	case "right", "l":
+		if m.savePromptFocus == savePromptFocusSave {
+			m.setSavePromptFocus(savePromptFocusSkip)
+		}
+		return m, textinput.Blink
+	case "enter":
+		switch m.savePromptFocus {
+		case savePromptFocusName:
+			m.setSavePromptFocus(savePromptFocusSave)
+			return m, textinput.Blink
+		case savePromptFocusSave:
+			if strings.TrimSpace(m.saveNameInput.Value()) == "" {
+				return m, nil
+			}
+			if _, err := m.store.Save(m.saveNameInput.Value(), m.pendingConnectionString); err != nil {
+				m.errMsg = fmt.Sprintf("failed to save connection string: %v", err)
+				return m, nil
+			}
+			if err := m.refreshSavedConnections(); err != nil {
+				m.errMsg = err.Error()
+				return m, nil
+			}
+			m.errMsg = ""
+			return m.finishPendingConnection()
+		case savePromptFocusSkip:
+			return m.skipPendingConnection()
+		}
+	default:
+		if m.savePromptFocus == savePromptFocusName {
+			var cmd tea.Cmd
+			m.saveNameInput, cmd = m.saveNameInput.Update(msg)
+			return m, cmd
+		}
+	}
+
+	return m, nil
+}
+
+func (m *AuthModel) moveSavePromptFocus(step int) {
+	next := int(m.savePromptFocus) + step
+	if next < 0 {
+		next = 2
+	}
+	if next > 2 {
+		next = 0
+	}
+	m.setSavePromptFocus(savePromptFocus(next))
+}
+
+func (m *AuthModel) setSavePromptFocus(focus savePromptFocus) {
+	m.savePromptFocus = focus
+	if focus == savePromptFocusName {
+		m.saveNameInput.Focus()
+	} else {
+		m.saveNameInput.Blur()
+	}
+}
+
+func (m *AuthModel) finishPendingConnection() (tea.Model, tea.Cmd) {
+	if m.pendingConnection == nil {
+		m.inSaveConnectionPrompt = false
+		return m, nil
+	}
+	connected := *m.pendingConnection
+	m.inSaveConnectionPrompt = false
+	m.pendingConnection = nil
+	m.pendingConnectionString = ""
+	m.saveNameInput.SetValue("")
+	return m, func() tea.Msg { return connected }
+}
+
+func (m *AuthModel) skipPendingConnection() (tea.Model, tea.Cmd) {
+	return m.finishPendingConnection()
 }
 
 func (m *AuthModel) updateServicePrincipalInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -308,7 +540,9 @@ func (m *AuthModel) View() string {
 		s.WriteString(styles.Subtle.Render("Connecting..."))
 		s.WriteString("\n")
 	} else {
-		if m.inConnectionStringMode {
+		if m.inSavedConnectionsMode {
+			m.viewSavedConnections(&s)
+		} else if m.inConnectionStringMode {
 			m.viewConnectionStringInput(&s)
 		} else if m.inServicePrincipalMode {
 			m.viewServicePrincipalInput(&s)
@@ -325,11 +559,20 @@ func (m *AuthModel) View() string {
 		}
 
 		s.WriteString("\n")
-		s.WriteString(styles.Subtle.Render("↑↓/jk: navigate | enter: select | esc: back | ctrl+c: quit"))
+		if m.inSavedConnectionsMode {
+			s.WriteString(styles.Subtle.Render("↑↓/jk: navigate | enter: connect | x/del: delete | esc: back | ctrl+c: quit"))
+		} else {
+			s.WriteString(styles.Subtle.Render("↑↓/jk: navigate | enter: select | esc: back | ctrl+c: quit"))
+		}
 		s.WriteString("\n")
 	}
 
-	return s.String()
+	view := s.String()
+	if m.inSaveConnectionPrompt {
+		return m.renderSaveConnectionPrompt(view)
+	}
+
+	return view
 }
 
 func (m *AuthModel) viewNamespaceSelection(s *strings.Builder) {
@@ -393,6 +636,30 @@ func (m *AuthModel) viewAuthSelection(s *strings.Builder) {
 	}
 }
 
+func (m *AuthModel) viewSavedConnections(s *strings.Builder) {
+	s.WriteString(styles.Subtle.Render("Saved Connection Strings"))
+	s.WriteString("\n\n")
+
+	for i, entry := range m.savedConnections {
+		entryID := entry.ID
+		if len(entryID) > 8 {
+			entryID = entryID[:8]
+		}
+		line := fmt.Sprintf("%s  %s", entry.Name, styles.Subtle.Render("("+entryID+")"))
+		if i == m.selectedSavedIdx {
+			s.WriteString(styles.Selected.Render("▶ " + line))
+		} else {
+			s.WriteString("  " + line)
+		}
+		s.WriteString("\n")
+	}
+
+	if len(m.savedConnections) == 0 {
+		s.WriteString(styles.Subtle.Render("No saved connection strings"))
+		s.WriteString("\n")
+	}
+}
+
 func (m *AuthModel) viewConnectionStringInput(s *strings.Builder) {
 	s.WriteString(styles.Subtle.Render("Enter Connection String"))
 	s.WriteString("\n\n")
@@ -418,6 +685,69 @@ func (m *AuthModel) viewServicePrincipalInput(s *strings.Builder) {
 		s.WriteString(m.servicePrincipalInputs[i].View())
 		s.WriteString("\n\n")
 	}
+}
+
+func (m *AuthModel) renderSaveConnectionPrompt(_ string) string {
+	panelWidth := min(60, max(m.width-4, 40))
+	panelHeight := min(14, max(m.height-4, 10))
+	// innerWidth: usable content area inside panel border+padding (same formula as send.go)
+	innerWidth := panelWidth - 6
+	// inputWidth: container width for renderTextInputField (its border+padding = 4 chars overhead)
+	inputWidth := max(innerWidth, 20)
+	m.saveNameInput.Width = inputWidth
+
+	nameEmpty := strings.TrimSpace(m.saveNameInput.Value()) == ""
+
+	var labelStr string
+	if m.savePromptFocus == savePromptFocusName {
+		labelStr = styles.Label.Render("Connection name")
+	} else {
+		labelStr = styles.Subtle.Render("Connection name")
+	}
+
+	renderButton := func(label string, focused bool, disabled bool) string {
+		borderColor := styles.Muted
+		textColor := styles.Muted
+		if focused && !disabled {
+			borderColor = styles.Primary
+			textColor = styles.Primary
+		}
+		return lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(borderColor).
+			Foreground(textColor).
+			Bold(focused && !disabled).
+			Padding(0, 1).
+			Render(label)
+	}
+
+	saveBtn := renderButton("save", m.savePromptFocus == savePromptFocusSave, nameEmpty)
+	skipBtn := renderButton("skip", m.savePromptFocus == savePromptFocusSkip, false)
+	buttons := lipgloss.JoinHorizontal(lipgloss.Top, saveBtn, "  ", skipBtn)
+
+	inputField := renderTextInputField(m.saveNameInput.View(), m.savePromptFocus == savePromptFocusName, inputWidth)
+	// align buttons right edge with input right edge by measuring actual rendered width
+	buttonsRow := lipgloss.NewStyle().Width(lipgloss.Width(inputField)).Align(lipgloss.Right).Render(buttons)
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		styles.Title.Render("Save connection string?"),
+		labelStr,
+		inputField,
+		"",
+		buttonsRow,
+		"",
+		styles.Subtle.Render("tab: focus next • enter: select • esc: skip"),
+	)
+
+	panelStyle := lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(styles.Primary).
+		Padding(1, 2).
+		Width(panelWidth).
+		Height(panelHeight)
+
+	overlay := panelStyle.Render(content)
+	return lipgloss.Place(max(m.width, 60), max(m.height+5, 20), lipgloss.Center, lipgloss.Center, overlay)
 }
 
 type NamespacesLoadedMsg struct {
@@ -513,7 +843,31 @@ func (m *AuthModel) connectWithConnectionStringCmd(connectionString string) tea.
 	}
 }
 
+func (m *AuthModel) connectWithConnectionStringAndPromptCmd(connectionString string) tea.Cmd {
+	return func() tea.Msg {
+		client, err := azure.NewServiceBusClientFromConnectionString(connectionString)
+		if err != nil {
+			return ErrorMsg(fmt.Sprintf("failed to connect with connection string: %v", err))
+		}
+
+		namespace := client.GetNamespace()
+
+		log.Printf("connected to namespace via connection string: %s", namespace)
+		return ConnectionStringConnectedMsg{
+			Namespace:        namespace,
+			Client:           client,
+			ConnectionString: strings.TrimSpace(connectionString),
+		}
+	}
+}
+
 type NamespaceConnectedMsg struct {
 	Namespace string
 	Client    *azure.ServiceBusClient
+}
+
+type ConnectionStringConnectedMsg struct {
+	Namespace        string
+	Client           *azure.ServiceBusClient
+	ConnectionString string
 }

--- a/internal/app/connection_store.go
+++ b/internal/app/connection_store.go
@@ -1,0 +1,206 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	connectionStoreDirName  = "service-bus-tui"
+	connectionStoreFileName = "connections.json"
+)
+
+var (
+	ErrEmptyConnectionName   = errors.New("connection name cannot be empty")
+	ErrEmptyConnectionString = errors.New("connection string cannot be empty")
+)
+
+type SavedConnection struct {
+	ID               string    `json:"id"`
+	Name             string    `json:"name"`
+	ConnectionString string    `json:"connectionString"`
+	CreatedAt        time.Time `json:"createdAt"`
+	LastUsedAt       time.Time `json:"lastUsedAt"`
+}
+
+type connectionStorePayload struct {
+	Connections []SavedConnection `json:"connections"`
+}
+
+type ConnectionStore struct {
+	path string
+}
+
+func NewConnectionStore() *ConnectionStore {
+	storePath, err := defaultConnectionStorePath()
+	if err != nil {
+		storePath = filepath.Join(connectionStoreDirName, connectionStoreFileName)
+	}
+	return &ConnectionStore{path: storePath}
+}
+
+func NewConnectionStoreAtPath(path string) *ConnectionStore {
+	return &ConnectionStore{path: path}
+}
+
+func (s *ConnectionStore) List() ([]SavedConnection, error) {
+	payload, err := s.readPayload()
+	if err != nil {
+		return nil, err
+	}
+
+	connections := append([]SavedConnection(nil), payload.Connections...)
+	sort.Slice(connections, func(i, j int) bool {
+		return connections[i].LastUsedAt.After(connections[j].LastUsedAt)
+	})
+
+	return connections, nil
+}
+
+func (s *ConnectionStore) Save(name, connectionString string) (SavedConnection, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return SavedConnection{}, ErrEmptyConnectionName
+	}
+
+	normalizedConnectionString := strings.TrimSpace(connectionString)
+	if normalizedConnectionString == "" {
+		return SavedConnection{}, ErrEmptyConnectionString
+	}
+
+	payload, err := s.readPayload()
+	if err != nil {
+		return SavedConnection{}, err
+	}
+
+	now := time.Now().UTC()
+	for i := range payload.Connections {
+		if normalizeConnectionString(payload.Connections[i].ConnectionString) == normalizedConnectionString {
+			payload.Connections[i].Name = trimmedName
+			payload.Connections[i].ConnectionString = normalizedConnectionString
+			if payload.Connections[i].CreatedAt.IsZero() {
+				payload.Connections[i].CreatedAt = now
+			}
+			payload.Connections[i].LastUsedAt = now
+
+			if err := s.writePayload(payload); err != nil {
+				return SavedConnection{}, err
+			}
+			return payload.Connections[i], nil
+		}
+	}
+
+	newEntry := SavedConnection{
+		ID:               uuid.NewString(),
+		Name:             trimmedName,
+		ConnectionString: normalizedConnectionString,
+		CreatedAt:        now,
+		LastUsedAt:       now,
+	}
+
+	payload.Connections = append(payload.Connections, newEntry)
+	if err := s.writePayload(payload); err != nil {
+		return SavedConnection{}, err
+	}
+
+	return newEntry, nil
+}
+
+func (s *ConnectionStore) Delete(id string) error {
+	trimmedID := strings.TrimSpace(id)
+	if trimmedID == "" {
+		return nil
+	}
+
+	payload, err := s.readPayload()
+	if err != nil {
+		return err
+	}
+
+	filtered := payload.Connections[:0]
+	for _, conn := range payload.Connections {
+		if conn.ID != trimmedID {
+			filtered = append(filtered, conn)
+		}
+	}
+	payload.Connections = filtered
+
+	return s.writePayload(payload)
+}
+
+func (s *ConnectionStore) readPayload() (connectionStorePayload, error) {
+	bytes, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return connectionStorePayload{Connections: []SavedConnection{}}, nil
+		}
+		return connectionStorePayload{}, fmt.Errorf("read saved connections: %w", err)
+	}
+
+	if len(bytes) == 0 {
+		return connectionStorePayload{Connections: []SavedConnection{}}, nil
+	}
+
+	var payload connectionStorePayload
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return connectionStorePayload{}, fmt.Errorf("parse saved connections: %w", err)
+	}
+	if payload.Connections == nil {
+		payload.Connections = []SavedConnection{}
+	}
+
+	return payload, nil
+}
+
+func (s *ConnectionStore) writePayload(payload connectionStorePayload) error {
+	if payload.Connections == nil {
+		payload.Connections = []SavedConnection{}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+
+	bytes, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode saved connections: %w", err)
+	}
+	bytes = append(bytes, '\n')
+
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, bytes, 0o600); err != nil {
+		return fmt.Errorf("write saved connections temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace saved connections file: %w", err)
+	}
+
+	if err := os.Chmod(s.path, 0o600); err != nil {
+		return fmt.Errorf("set saved connections file permissions: %w", err)
+	}
+
+	return nil
+}
+
+func defaultConnectionStorePath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user config dir: %w", err)
+	}
+
+	return filepath.Join(configDir, connectionStoreDirName, connectionStoreFileName), nil
+}
+
+func normalizeConnectionString(value string) string {
+	return strings.TrimSpace(value)
+}


### PR DESCRIPTION
Prompt user to save a connection string after a successful connection. Saved connections are persisted locally and listed as a selectable auth option on subsequent launches. Supports deleting saved entries.